### PR TITLE
Variable Fix

### DIFF
--- a/autodiscover/autodiscover.php
+++ b/autodiscover/autodiscover.php
@@ -28,7 +28,7 @@ if (filter_var($email[1], FILTER_VALIDATE_EMAIL) === false) {
 }
 
 // get domain from email address
-$domain = substr( strrchr( $email, "@" ), 1 );
+$domain = substr( strrchr( $email[1], "@" ), 1 );
 
 /**************************************
  *   Port and server settings below   *

--- a/autodiscover/autodiscover.php
+++ b/autodiscover/autodiscover.php
@@ -28,7 +28,7 @@ if (filter_var($email[1], FILTER_VALIDATE_EMAIL) === false) {
 }
 
 // get domain from email address
-$domain = substr( strrchr( $request, "@" ), 1 );
+$domain = substr( strrchr( $email, "@" ), 1 );
 
 /**************************************
  *   Port and server settings below   *


### PR DESCRIPTION
I noticed that the variable was wrong in the statement:
`$domain = substr( strrchr( $request, "@" ), 1 );`
This line of code pulls everything in the XML response after the "@" symbol so the $domain variable ends up looking something like
`<Server>pop.example.com</EMailAddress><AcceptableResponseSchema>http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a</AcceptableResponseSchema></Request></Autodiscover></Server>`
When it should look like:
`<Server>mail.example.com</Server>`