### PR TITLE
Create nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,19 @@
+server {
+        listen 443;
+        server_name autodiscover.DOMAINHERE.com;
+        root /var/www/vhosts/DOMAINHERE.com;
+        ssl_certificate /etc/letsencrypt/live/autodiscover.DOMAINHERE.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/autodiscover.DOMAINHERE.com/privkey.pem;
+
+        location / {
+                try_files $uri $uri/ /autodiscover.php$is_args$args;
+                default_type text/xml;
+        }
+
+
+        # Pass PHP scripts to PHP-FPM
+        location ~ \.php$ {
+                include snippets/fastcgi-php.conf;
+                fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+        }
+}


### PR DESCRIPTION
Adding an example of NGINX config. This can be used if a server is running Nginx rather than apache.